### PR TITLE
Feature: Apollo Redesign CleanUp

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -29,20 +29,22 @@
 
 /* Default variant */
 .apollo[data-apollo="Button"].default {
-    background: #25E685;
+    background: #1B75BC;
+    color: white;
 }
 
 .apollo[data-apollo="Button"].default:hover {
-    background: #A1EFC9;
+    background: #4991C9;
+    color: white;
 }
 
 .apollo[data-apollo="Button"].default:focus {
-    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #CAF2E1;
+    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #1F477B;
 }
 
 .apollo[data-apollo="Button"].default:disabled {
-    background: #CAF2E1;
-    color: #98A7AD;
+    background: #edeff1;
+    color: #98a7ad;
 }
 
 /* Secondary Variant */

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -33,13 +33,8 @@
     color: white;
 }
 
-.apollo[data-apollo="Button"].default:hover {
-    background: #4991C9;
-    color: white;
-}
-
 .apollo[data-apollo="Button"].default:focus {
-    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #1F477B;
+    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #a4c8e4;
 }
 
 .apollo[data-apollo="Button"].default:disabled {
@@ -50,11 +45,11 @@
 /* Secondary Variant */
 .apollo[data-apollo="Button"].secondary {
     background: white;
-    border: 1.5px solid #10333F;
+    border: 1.5px solid #1B75BC;
 }
  
 .apollo[data-apollo="Button"].secondary:hover {
-    background: #10333F;
+    background: #1B75BC;
     color: white;
 }
 
@@ -90,25 +85,10 @@
     background: transparent;
 }
 
-.apollo-component-library-button:hover {
-    filter: brightness(90%);
+.apollo[data-apollo="Button"]:hover {
+    filter: brightness(120%);
 }
 
-.apollo-component-library-button:active {
-    filter: brightness(75%);
-}
-
-/* variants should be defined as followed */
-.apollo-component-library-button.default {
-    background: #ff5757;
-}
-
-.apollo-component-library-button.secondary {
-    background: #57aeff;
-}
-
-.apollo-component-library-button.area {
-    background: none;
-    border: none;
-    padding: 0px;
+.apollo[data-apollo="Button"]:active {
+    filter: brightness(100%);
 }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -6,6 +6,14 @@
     padding-top: 4px;
 }
 
+.apollo-component-library-icon-component:hover {
+    cursor: pointer;
+    padding-top: 0;
+    background: #c6ced3;
+    border-radius: 5px;
+    margin-right: 15px;
+}
+
 .apollo-component-library-icon-component:active {
     filter: brightness(90%);
 }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -1,31 +1,23 @@
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 
-.apollo-component-library-icon-component {
+.apollo[data-apollo="Icon"] {
     user-select: none;
     margin: 0;
-    padding-top: 4px;
 }
 
-.apollo-component-library-icon-component:hover {
-    cursor: pointer;
-    padding-top: 0;
-    background: #c6ced3;
-    border-radius: 5px;
-    margin-right: 15px;
-}
-
-.apollo-component-library-icon-component:active {
+.apollo[data-apollo="Icon"]:active {
     filter: brightness(90%);
 }
 
-.apollo-component-library-icon-component.default {
+.apollo[data-apollo="Icon"].default {
     background: transparent;
-    transition: background 300ms, filter 300ms  ;
+    transition: background 300ms, filter 300ms, color 300ms;
     border-radius: 25px;
     padding: 5px;
 }
 
-.apollo-component-library-icon-component.default:hover {
+.apollo[data-apollo="Icon"].default:hover {
     cursor: pointer;
-    background: #A1EFC9;
+    background: #1b75bc;
+    color: white;
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -57,8 +57,8 @@ export const Icon: FC<IIcon> = forwardRef(function Icon(
             onKeyDown={(event) =>
                 (event.key === 'Enter' || event.key === ' ') && onClick && onClick()
             }
-            className={`material-icons apollo-component-library-icon-component 
-                ${clickable && variant} ${className}`}
+            className={`material-icons apollo
+                ${clickable ? variant : ''} ${className}`}
             onClick={onClick}
         >
             {name}

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -19,13 +19,14 @@
     min-height: 200px;
     background: white;
     z-index: 1;
-    border-radius: 15px;
+    border-radius: 12px;
     box-sizing: border-box;
-    padding: 15px;
+    padding: 24px;
     align-self: center;
     justify-self: center;
     display: flex;
     flex-direction: column;
+    
 }
 
 .apollo-component-library-modal-component-backdrop {

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -32,8 +32,7 @@
     width: 100%;
 }
 
-.apollo[data-apollo="Select"] > span[data-apollo-id="select-button"]:focus-within,
-.apollo[data-apollo="Select"] input:focus {
+.apollo[data-apollo="Select"] > span[data-apollo-id="select-button"]:focus-within { 
     box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #a4c8e4;
     border: 1.5px solid #1F477B;
 }

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -32,9 +32,10 @@
     width: 100%;
 }
 
-.apollo[data-apollo="Select"] > span[data-apollo-id="select-button"]:focus-within {
-    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #CAF2E1;
-    border: 1.5px solid #25E685;
+.apollo[data-apollo="Select"] > span[data-apollo-id="select-button"]:focus-within,
+.apollo[data-apollo="Select"] input:focus {
+    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #a4c8e4;
+    border: 1.5px solid #1F477B;
 }
 
 .apollo[data-apollo="Select"].invalid > span[data-apollo-id="select-button"] {
@@ -42,5 +43,5 @@
 }
 
 .apollo[data-apollo="Select"].invalid > span[data-apollo-id="select-button"]:focus {
-    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05); 
+    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #a4c8e4;
 }

--- a/src/components/TextInput/TextInput.css
+++ b/src/components/TextInput/TextInput.css
@@ -1,4 +1,4 @@
-.apollo-component-library-text-input {
+.apollo[data-apollo="TextInput"] {
     font-size: 1rem;
     border: none;
     outline: none;
@@ -10,37 +10,37 @@
     transition: box-shadow 300ms, border 300ms;
 }
 
-.apollo-component-library-text-input-label {
+.apollo[data-apollo-id="TextInput-Label"] {
     padding-bottom: 15px;
 }
 
-.apollo-component-library-text-input.default {
+.apollo[data-apollo="TextInput"].default {
     box-shadow: 0px 0px 0px 0px #CAF2E1;
 }
 
-.apollo-component-library-text-input.default:focus {
-    border: 1.5px solid #25E685;
-    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #CAF2E1;
+.apollo[data-apollo="TextInput"].default:focus {
+    box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #a4c8e4;
+    border: 1.5px solid #0e214b;
 }
 
-.apollo-component-library-text-input.secondary {
+.apollo[data-apollo="TextInput"].secondary {
     box-shadow: 0px 0px 0px 0px lightblue;
 }
 
-.apollo-component-library-text-input.secondary:focus {
+.apollo[data-apollo="TextInput"].secondary:focus {
     box-shadow: 0px 2px 0px 0px lightblue;
 }
 
-.apollo-component-library-text-input.invalid {
+.apollo[data-apollo="TextInput"].invalid {
     border: 1.5px solid #FDA29B;
 }
 
-.apollo-component-library-text-input.invalid:focus {
+.apollo[data-apollo="TextInput"].invalid:focus {
     border: 1.5px solid #FDA29B;
     box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #FEE4E2;
 }
 
-.apollo-component-library-text-input-label input[data-apollo="TextInput"] {
+.apollo[data-apollo-id="TextInput-Label"] .apollo[data-apollo="TextInput"] {
     width: 100%;
     box-sizing: border-box;
 }

--- a/src/components/TextInput/TextInput.css
+++ b/src/components/TextInput/TextInput.css
@@ -39,3 +39,8 @@
     border: 1.5px solid #FDA29B;
     box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #FEE4E2;
 }
+
+.apollo-component-library-text-input-label input[data-apollo="TextInput"] {
+    width: 100%;
+    box-sizing: border-box;
+}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -72,7 +72,7 @@ export const TextInput: FC<ITextInput> = ({
     }, []);
 
     return (
-        <div className="apollo-component-library-text-input-label">
+        <div className="apollo" data-apollo-id="TextInput-Label">
             <label>
                 <Text style={labelTextStyle} color="#10333F">
                     {label}{' '}
@@ -89,7 +89,8 @@ export const TextInput: FC<ITextInput> = ({
                     aria-invalid={invalid}
                     aria-errormessage={name ? `${name}-error` : `${label}-error`}
                     type={password ? 'password' : 'text'}
-                    className={`apollo-component-library-text-input 
+                    className={`
+                        apollo
                         ${variant} 
                         ${!invalid ? 'valid' : 'invalid'}
                         ${className}


### PR DESCRIPTION
# Feature: Apollo Redesign CleanUp
In This PR I  cleaned Apollo design to be more simple and focused and to entirely support quicksilver.
- [ahmedpythondev/mil-1291-chore-redesign-apollo](https://linear.app/milemarker10/issue/MIL-1291/chore-redesign-apollo)

## Purpose
To have a more clean interface and to support quicksilver

## Summary of Changes

**Button**
- Disabled State
- Focused State
- Default State
- Hover State

**Select Menu**
- Focus State

**Text Input**
- Focus State

**Modal**
- Default State

**Icon**
- Hover
- Focus

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.