### PR TITLE
Feature/eddie lopez/mil 1429 component recreate loader in css

### DIFF
--- a/src/components/Spinner/Spinner.css
+++ b/src/components/Spinner/Spinner.css
@@ -1,0 +1,22 @@
+.apollo[data-apollo='Spinner'] {
+    border-radius: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: spin 1000ms infinite linear;
+}
+
+.apollo[data-apollo='Spinner'] > div {
+    width: 80%;
+    height: 80%;
+    border-radius: 100%;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(360deg);
+    }
+    100% {
+        transform: rotate(0deg);
+    }
+}

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,84 @@
+import type { Apollo } from '../../interfaces/Apollo';
+import type * as CSS from 'csstype';
+import type { CSSProperties, FC } from 'react';
+
+import React from 'react';
+import { StyleVariant } from '../../interfaces/Properties';
+import { HTMLAttributes } from 'react';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+import './Spinner.css';
+
+interface ISpinner extends HTMLAttributes<HTMLDivElement>, Apollo<'Spinner'> {
+    /** Determines the color of the spinner */
+    color?: CSS.Property.Color;
+    /** Determines inner color of the spinner */
+    innerColor?: CSS.Property.Color;
+    /** Determines the size of the spinner */
+    size?: CSS.Property.Height;
+    /** Determines the variant of the spinner */
+    variant?: StyleVariant;
+    /** Displays spinner */
+    loading?: boolean;
+}
+
+/**
+ * This component is the standard spinner for the Apollo Component Library.
+ *
+ * @return Spinner component
+ */
+export const Spinner: FC<ISpinner> = ({
+    color = '#95a0a8',
+    size = '50px',
+    innerColor = 'white',
+    variant,
+    loading,
+    style,
+    ...props
+}) => {
+    gaurdApolloName(props, 'Spinner');
+
+    return loading ? (
+        <div
+            {...props}
+            style={getSpinnerStyle({ color, size, style, variant })}
+            className="apollo"
+            role="status"
+            aria-label="Loading..."
+        >
+            <div style={{ backgroundColor: innerColor }} />
+        </div>
+    ) : null;
+};
+
+/**
+ * Gets the style of the spinner
+ *
+ * @return spinner style
+ */
+const getSpinnerStyle = ({ color, size, style, variant }: ISpinner): CSSProperties => {
+    let finalColor = color;
+
+    if (variant) {
+        switch (variant) {
+            case 'secondary':
+                finalColor = '#10333f';
+                break;
+            case 'tertiary':
+                finalColor = '#1b75bc';
+                break;
+            default:
+                finalColor = '#95a0a8';
+                break;
+        }
+    }
+
+    return {
+        backgroundImage: `conic-gradient(${finalColor} 25%, transparent 100%)`,
+        height: size,
+        width: size,
+        ...style,
+    };
+};
+
+Spinner.defaultProps = { 'data-apollo': 'Spinner' };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ export { Select } from './components/Select/Select';
 export { Avatar } from './components/Avatar/Avatar';
 export { Grid } from './components/Grid/Grid';
 export { Image } from './components/Image/Image';
+export { Spinner } from './components/Spinner/Spinner';
 
 export type {
     FormValidator,

--- a/stories/Spinner.stories.mdx
+++ b/stories/Spinner.stories.mdx
@@ -1,0 +1,78 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
+import { linkTo } from '@storybook/addon-links';
+
+import { Spinner } from '../src';
+
+import {
+    DefaultState,
+    DifferentColorSpinners,
+    DifferentSizeSpinners,
+    DifferentVariantSpinners,
+} from './examples/Spinner';
+
+<Meta title="Layout/Spinner" component={Spinner} />
+
+# Spinner
+
+The spinner is the busy loading state in Apollo. It's purpose is to let the user
+know that a process is currently running in the background.
+
+## Table of Contents
+
+-   [Functionality](#functionality)
+    -   [Customization](#default-state)
+        -   [Colors](#colors)
+        -   [Sizes](#sizes)
+        -   [Variants](#variants)
+-   [Other Props & Functionalities](#other-props--functionalities)
+
+## Functionality
+
+The functionality of the loading spinner is pretty simple. All you have to do is toggle
+the `loading` prop to true, and you will be able to see this spinner in action. You can
+play around with this feature below.
+
+<Canvas>
+    <Story name="Default State">{DefaultState.bind({})}</Story>
+</Canvas>
+
+### Customization
+
+The spinner is also highly customizable to fit the needs and wants of your application.
+
+#### Colors
+
+The spinner supports two types of color changes. The prop `color` refers to the color of the
+spinner itself, while the `innerColor` prop refers to the color of the spinner's inner circle
+(This is likely to change in the near future).
+
+<Canvas>
+    <Story name="Different Color Spinners">{DifferentColorSpinners.bind({})}</Story>
+</Canvas>
+
+#### Sizes
+
+The spinner can also have different sizes, meaning that it will always be able to fit the
+dimensions that you need it to, making it highly versatile for your usecase.
+
+<Canvas>
+    <Story name="Different Size Spinners">{DifferentSizeSpinners.bind({})}</Story>
+</Canvas>
+
+#### Variants
+
+You can also customize your spinner using the `variant` prop. These variants are theme based
+meaning that if you want quick access to designated colors to your theme, you can do so by
+using the variant props.
+
+<Canvas>
+    <Story name="Different Variant Spinners">{DifferentVariantSpinners.bind({})}</Story>
+</Canvas>
+
+## Other Props & Functionalities
+
+For the full list of props that spinners have, please refer to the table below. Also keep
+in mind that this component extends the `div` element, so it can recieve any properties
+compatible with it.
+
+<ArgsTable of={Spinner} />

--- a/stories/examples/Spinner.tsx
+++ b/stories/examples/Spinner.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import type { SampleStory } from './util';
+import { Button, Grid, Spinner, Text } from '../../src';
+
+export const DefaultState: SampleStory = (args) => {
+    const [loading, setLoading] = useState(false);
+
+    return (
+        <div>
+            <Button onClick={() => setLoading(!loading)} style={{ marginBottom: 20 }}>
+                Toggle Spinner
+            </Button>
+            <Spinner loading={loading} {...args} />
+        </div>
+    );
+};
+
+export const DifferentColorSpinners: SampleStory = (args) => (
+    <>
+        <Text header={2} margins>
+            Color
+        </Text>
+        <Grid columns="auto auto auto" width="300px" style={{ marginBottom: 20 }}>
+            <Spinner color="red" loading />
+            <Spinner color="green" loading />
+            <Spinner color="blue" loading />
+        </Grid>
+        <Text header={2} margins>
+            Inner Color
+        </Text>
+        <Grid columns="auto auto auto" width="300px">
+            <Spinner innerColor="red" loading />
+            <Spinner innerColor="green" loading />
+            <Spinner innerColor="blue" loading />
+        </Grid>
+    </>
+);
+
+export const DifferentSizeSpinners: SampleStory = (args) => (
+    <>
+        <Grid columns="auto auto auto" width="300px">
+            <Spinner size="50px" loading />
+            <Spinner size="70px" loading />
+            <Spinner size="40px" loading />
+        </Grid>
+    </>
+);
+
+export const DifferentVariantSpinners: SampleStory = (args) => (
+    <>
+        <Grid columns="auto auto auto" width="300px">
+            <Spinner loading />
+            <Spinner variant="secondary" loading />
+            <Spinner variant="tertiary" loading />
+        </Grid>
+    </>
+);

--- a/test/Spinner.test.tsx
+++ b/test/Spinner.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+import { Spinner } from '../src';
+
+describe('Spinner', () => {
+    it('renders correctly', () => {
+        // given
+        render(<Spinner />);
+
+        // when then
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('has no accessibility violations', async () => {
+        // given
+        const { container } = render(<Spinner loading />);
+
+        // when
+        const results = await axe(container);
+
+        // then
+        expect(results).toHaveNoViolations();
+    });
+
+    it('renders correctly with loading', () => {
+        // given
+        render(<Spinner loading />);
+
+        // when then
+        expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# Recreated Spinner component
Created a standalone spinner component for Apollo. This component will deprecate the `LoadingState` spinner.

- Fixes MIL-1429

## Purpose
This is a necessary change that we need to see in Quicksilver that can be easily done through Apollo. Adding this feature will also allow us to quickly add the loading state to other Apollo components which will in turn make development of Quicksilver quicker.

## Summary of Changes
Added a spinner with the capability of being visible via a `loading` prop. This component can be altered in both size and color and can even accept a variant prop that will align with the theming in the future.

### Changelog

- Created `Spinner` component
- Created `Spinner` test file which checks for:
  - `Spinner` visibility
  - `Spinner` accessibility
- Created `Spinner` documentation

### Images

Here are several screenshots showing the assets created.

#### Spinner toggled by button
<img width="155" alt="image" src="https://user-images.githubusercontent.com/52265974/184930429-ff7495ad-157a-4e2b-a480-7cd5f95f42da.png">

#### Different types of spinner colors
<img width="206" alt="image" src="https://user-images.githubusercontent.com/52265974/184930642-e3f04e1b-2e08-4fda-a8cb-752fbbad5e41.png">

#### Different colors of the spinners
<img width="214" alt="image" src="https://user-images.githubusercontent.com/52265974/184930731-e344d45d-0d50-4839-b862-290179db1011.png">

#### Different variants of the spinner
<img width="210" alt="image" src="https://user-images.githubusercontent.com/52265974/184931036-b04225d5-ec8a-4443-8fab-75afee997293.png">

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.