### PR TITLE
component: added loading state to button

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -92,3 +92,7 @@
 .apollo[data-apollo="Button"]:active {
     filter: brightness(100%);
 }
+
+.apollo[data-apollo="Button"]:disabled:hover {
+    filter: none;
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,6 +8,8 @@ import type { StyleVariant } from '../../interfaces/Properties';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
+import { Spinner } from '../Spinner/Spinner';
+import { Section } from '../Section/Section';
 
 export interface IButton extends HTMLAttributes<HTMLButtonElement>, Apollo<'Button'> {
     /** Required ReactNode that needs to exist between component tags */
@@ -20,6 +22,10 @@ export interface IButton extends HTMLAttributes<HTMLButtonElement>, Apollo<'Butt
     disabled?: boolean;
     /** Allows use of references */
     ref?: ForwardedRef<HTMLButtonElement>;
+    /** Determines the type of button */
+    type?: 'button' | 'submit' | 'reset';
+    /** Determines whether the button is loading or not */
+    loading?: boolean;
 }
 
 /**
@@ -28,7 +34,7 @@ export interface IButton extends HTMLAttributes<HTMLButtonElement>, Apollo<'Butt
  * @return Button component
  */
 export const Button: FC<IButton> = forwardRef(function Button(
-    { children, className = '', disabled, variant = 'default', ...props }: IButton,
+    { children, className = '', loading, disabled, variant = 'default', ...props }: IButton,
     ref: ForwardedRef<HTMLButtonElement>
 ) {
     gaurdApolloName(props, 'Button');
@@ -36,11 +42,18 @@ export const Button: FC<IButton> = forwardRef(function Button(
     return (
         <button
             {...props}
-            disabled={disabled}
+            aria-busy={loading}
+            disabled={disabled || loading}
             className={`apollo ${variant} ${className}`}
             ref={ref}
         >
-            <Text>{children}</Text>
+            {!loading ? (
+                <Text>{children}</Text>
+            ) : (
+                <Section center>
+                    <Spinner size="1rem" loading innerColor="#edeff1" />
+                </Section>
+            )}
         </button>
     );
 });

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -1,7 +1,8 @@
 import { useRef } from 'react';
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 import { linkTo } from '@storybook/addon-links';
-import { Button } from '../src'; // components you used in the story
+import { Button } from '../src'
+import { StandardButton, ButtonVariants, ButtonRefs, LoadingButton } from './examples/Button'
 
 <Meta title="Layout/Button" component={Button} />
 
@@ -11,6 +12,14 @@ The Button component is probably one of the biggest forms of input that Apollo h
 Something as simple as the button can make or break the experience for the user, and our aim
 was to make it as familiar as possible.
 
+## Table of Contents
+
+- [Functionality](#functionality)
+    - [Variants](#variants)
+    - [References](#references)
+    - [Loading state](#loading-state)
+- [Other Props & Functionalities](#other-props--functionalities)
+
 ## Functionality
 
 Functionally these buttons would work as you would expect them to. You hover or tab over it and
@@ -19,11 +28,15 @@ added very few additional features to it so it isn't too much of a pain to learn
 
 <Canvas>
     <Story name="Standard Button" args={{ children: "Click Me" }}>
-        {(args) => <Button {...args} />}
+        {StandardButton.bind({})}
     </Story>
 </Canvas>
 
-### Variants
+### Customization
+
+The buttons can recieve customization both in aesthetics and functionality.
+
+#### Variants
 
 The Button component for the moment only has 2 visual states that can be switched using the
 `variant` prop. These are the `"default"` and `"secondary"` variants. These variants can just
@@ -48,21 +61,29 @@ difference.
     </Story>
 </Canvas>
 
-### References
+#### References
 
 Since you can put references in a regular `button` element, we wanted to retain that functionality
 in Apollo. So if you find the need, don't shy away from using references, we support them :)
 
 <Canvas>
     <Story name="Button Refs">
-        {(args) => {
-            const ref = useRef(null);
-            return (
-                <Button ref={ref} onClick={() => window.alert(`button ref: ${ref.current}`)}>
-                    Click me
-                </Button>
-            );
-        }}
+        {ButtonRefs.bind({})}
+    </Story>
+</Canvas>
+
+### Loading state
+
+The button actually comes with a built in loading state that when enabled, will disabled the button
+and render a spinner within it. This is useful for instances where you need to wait for a response in
+a given form. To activate it all you have to do is toggle its `loading` prop to `true` as seen below.
+
+> **Note:** This component will also have an `aria-busy` attribute set to `true` when loading so that
+> screen readers will know that the button is loading.
+
+<Canvas>
+    <Story name="Loading Button">
+        {LoadingButton.bind({})}
     </Story>
 </Canvas>
 

--- a/stories/examples/Button.tsx
+++ b/stories/examples/Button.tsx
@@ -1,0 +1,25 @@
+import React, { useState, useRef } from 'react';
+import type { SampleStory } from './util';
+import { Button } from '../../src';
+
+export const StandardButton: SampleStory = (args) => <Button {...args} />;
+
+export const ButtonRefs: SampleStory = (args) => {
+    const ref = useRef(null);
+
+    return (
+        <Button ref={ref} onClick={() => window.alert(`button ref: ${ref.current}`)}>
+            Click me
+        </Button>
+    );
+};
+
+export const LoadingButton: SampleStory = (args) => {
+    const [loading, setLoading] = useState(false);
+
+    return (
+        <Button onClick={() => setLoading(!loading)} loading={loading}>
+            Click me
+        </Button>
+    );
+};

--- a/test/Button.test.tsx
+++ b/test/Button.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
 
 import { Button } from '../src';
 
@@ -11,6 +13,68 @@ describe('Button', () => {
 
         // when then
         expect(screen.getByText(/hello world!/i)).toBeInTheDocument();
+    });
+
+    it('complies with WCAG 2.0 AA', async () => {
+        // given
+        const { container: defaultButton } = render(<Button>Hello World!</Button>);
+        const { container: loadingButton } = render(<Button loading>Hello World!</Button>);
+        const { container: disabledButton } = render(<Button disabled>Hello World!</Button>);
+
+        // when
+        const results: any[] = [];
+        results.push(await axe(defaultButton));
+        results.push(await axe(loadingButton));
+        results.push(await axe(disabledButton));
+
+        // then
+        results.forEach((result) => {
+            expect(result).toHaveNoViolations();
+        });
+    });
+
+    it('will not be clickable when disabled', () => {
+        // given
+        const onClick: jest.Mock<any, any> = jest.fn();
+        render(
+            <Button disabled onClick={onClick}>
+                Hello World!
+            </Button>
+        );
+        const button = screen.getByRole('button');
+
+        // when
+        userEvent.click(button);
+
+        // then
+        expect(button).toBeDisabled();
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('renders correctly with loading', () => {
+        // given
+        render(<Button loading>Hello World!</Button>);
+
+        // when then
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByText(/hello world!/i)).not.toBeInTheDocument();
+    });
+
+    it('will not be clickable when loading', () => {
+        // given
+        const onClick: jest.Mock<any, any> = jest.fn();
+        render(
+            <Button loading onClick={onClick}>
+                Hello World!
+            </Button>
+        );
+        const button = screen.getByRole('button');
+
+        // when
+        userEvent.click(button);
+
+        // then
+        expect(onClick).not.toHaveBeenCalled();
     });
 
     it('will call onClick call back', () => {


### PR DESCRIPTION
# Added loading state to Button
Added a loading state to the `Button` component in Apollo which was needed because of a QA requirement given by Vicky

- Fixes MIL-1434

## Purpose
This update was necessary so that we can add a loadings state for situations like a form submission. By having this functionality available, we are letting our users know to not click the button again because there is a pending submission.

## Summary of Changes
Added a loading state to the button that can be toggled via the `loading` prop. This enables us to expand our use of the `Button` and improve UX for certain scenarios

### Changelog

- Added the `loading` prop to the Button
  - When `loading` is set to `true`:
    - `Spinner` component will appear in the `Button` component
    - The `Button` will be disabled so that it can't be clicked
- Updated documentation for the `Button` component to include the new functionality
- Added a `Button.tsx` file in `stories/examples` folder to abstract code examples
- Updated tests for Button to:
  - Ensure that button being rendered is accessible
  - Ensure that button is being rendered properly
  - Ensure that button cannot be clicked when disabled or loading

### Images
Here is a screenshot of the new changes

![image](https://user-images.githubusercontent.com/52265974/184969485-363e01ff-b264-4b4e-9297-01b96181eac5.png)

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.