### PR TITLE
component: updated dropdown and image components (#90)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.33",
+    "version": "0.1.37",
     "license": "MIT",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/src/components/Image/Image.css
+++ b/src/components/Image/Image.css
@@ -2,6 +2,15 @@
     position: relative;
 }
 
+.apollo[data-apollo="Image"] > .apollo[data-apollo="View"]:first-child {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    width: 100%;
+    height: 100%;
+}
+
 .apollo[data-apollo='Image'] > .apollo[data-apollo='View']:last-child {
     position: absolute;
     top: 0;

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -77,7 +77,11 @@ export const Image: FC<IImage> = ({
                 aria-hidden={loaded === 'loading'}
                 style={{ opacity: loaded === 'loading' ? 1 : 0 }}
             >
-                <Spinner loading innerColor="#eef1f2" label={`loading ${alt} image`} />
+                <Spinner
+                    loading={loaded === 'loading'}
+                    innerColor="#eef1f2"
+                    label={`loading ${alt} image`}
+                />
             </View>
         </div>
     );


### PR DESCRIPTION
The main changes that were made to Apollo include the addition of indicative arrows to all variants of `Dropdown` components. This is to be more inline with a previous issue with the UI. Additionally, we updated the `Image` component to use the new `Spinner` component instead of having its own custom element embedded within.

Other changes in this PR include:

- Updated Theming to not overwrite any other component style changes
- Updated theming documentation
- Added `label` prop to `Spinner` in order to overwrite default aria-labeling
- Removed unnecessary styling in `Image`