### PR TITLE
Created method to Deep replace

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -40,8 +40,6 @@ export const Button: FC<IButton> = forwardRef(function Button(
         variant = 'solid',
         loading,
         disabled,
-        onMouseEnter,
-        onMouseLeave,
         ...props
     }: IButton,
     ref: ForwardedRef<HTMLButtonElement>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,3 +46,5 @@ export type {
     DataRenderer,
 } from './interfaces/Properties';
 export type { ApolloTheme } from './interfaces/Theme';
+
+export { default as HandleOverloads } from './util/HandleOverloads';

--- a/src/util/DeepFormat.tsx
+++ b/src/util/DeepFormat.tsx
@@ -1,0 +1,109 @@
+import React, { Children, cloneElement, Fragment } from 'react';
+import { ParentProps } from '../interfaces/Overload';
+
+export interface ComponentMap {
+    /** All different sought out components */
+    [displayName: string]: React.FC<any>;
+}
+
+export default class DeepFormat {
+    private formattedChildren: JSX.Element[] = [];
+    private static internalIndex = 0;
+
+    /**
+     * Helper function that will replace all sought out components with their formatted
+     * counterparts, regardless of depth in DOM.
+     *
+     * @param child the children to execute deep replacement
+     * @param componentMap map of components to replace
+     * @param parentProps properties to pass to the parent component
+     * @return formatted children
+     */
+    static replace = (
+        child: JSX.Element,
+        componentMap: ComponentMap,
+        parentProps: ParentProps
+    ): JSX.Element => {
+        // extract child apollo name
+        const childName = child?.props?.['data-apollo'] || 'not-found';
+
+        // if child is a sought out component, replace it with its formatted counterpart
+        if (componentMap[childName]) {
+            // get component format
+            const { [childName]: Component } = componentMap;
+
+            // get required props
+            const {
+                ref,
+                props: { parentProps: childParentProps, ...childProps },
+            } = child as any;
+
+            // clone element and return
+            const formattedComponent: JSX.Element = (
+                <Component
+                    {...childProps}
+                    ref={ref}
+                    key={`deepFormat-${childName}-${DeepFormat.internalIndex}`}
+                />
+            );
+
+            DeepFormat.internalIndex++;
+            return cloneElement(formattedComponent, {
+                parentProps,
+            });
+        }
+
+        // return the child with its replaced children
+        const key = `deepFormat-component-${DeepFormat.internalIndex}`;
+        DeepFormat.internalIndex++;
+
+        // check if child has override props
+        const overloads = child?.props?.['apollo-overloads'];
+        if (overloads && Object.keys(overloads).some((key) => !!componentMap[key])) {
+            const newOverloads = { parentProps, ...overloads, ...componentMap };
+            return (
+                <Fragment key={key}>
+                    {cloneElement(child, { 'apollo-overloads': newOverloads })}
+                </Fragment>
+            );
+        }
+
+        // return the child if there are no children or is an apollo component
+        if (!child?.props?.children || childName !== 'not-found')
+            return <Fragment key={key}>{child}</Fragment>;
+
+        // if child has children, recursively replace them
+        const children = Children.map(child.props.children, (c) =>
+            DeepFormat.replace(c, componentMap, parentProps)
+        );
+
+        return <Fragment key={key}>{cloneElement(child, child.props, children)}</Fragment>;
+    };
+
+    /**
+     * This object will take the children property of any component and replace all coinciding
+     * elements with their formatted counterparts stated in the `componentMap` parameter. You
+     * can also pass in a `parentProps` parameter to pass props to the replaced components.
+     *
+     * @param children Children property
+     * @param componentMap map containing all component replacements
+     * @param parentProps properties to pass to replaced components
+     */
+    constructor(children: any, componentMap: ComponentMap = {}, parentProps: ParentProps = {}) {
+        // loop through all children
+        Children.forEach(children, (child: JSX.Element, index: number) => {
+            // replace child
+            const formattedChild = DeepFormat.replace(child, componentMap, parentProps);
+
+            // add child to formatted children
+            this.formattedChildren[index] = formattedChild;
+        });
+    }
+
+    /**
+     * Returns the formatted children.
+     *
+     * @return formatted children
+     */
+    getAll = (): JSX.Element[] => this.formattedChildren;
+}

--- a/src/util/HandleOverloads.tsx
+++ b/src/util/HandleOverloads.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+import { ParentProps, RenderAll } from '../interfaces/Overload';
+import DeepFormat from './DeepFormat';
+
+interface IApolloWrapper {
+    /** Children that will need Apollo Processing */
+    children: any;
+    /** component properties */
+    props: {
+        [key: string]: any;
+        'apollo-overrides'?: { [key: string]: any; parentProps?: ParentProps };
+    };
+}
+
+/**
+ * This component will perpetuate apollo processing to all children
+ *
+ * @return apollo processed children
+ */
+const HandleOverloads: FC<IApolloWrapper> = ({
+    props: { 'apollo-overloads': overloads },
+    children,
+}) => {
+    /**
+     * This function will render all children with DeepFormat.
+     *
+     * @return formatted children
+     */
+    const renderAll: RenderAll = () => {
+        if (!overloads || !overloads?.parentProps) return children;
+
+        const { parentProps, ...componentMap } = overloads;
+
+        // get deep format
+        const deepFormat = new DeepFormat(children, componentMap, parentProps);
+
+        // return formatted children
+        return deepFormat.getAll();
+    };
+
+    return <>{renderAll()}</>;
+};
+
+export default HandleOverloads;

--- a/test/DeepFormat.test.tsx
+++ b/test/DeepFormat.test.tsx
@@ -1,0 +1,205 @@
+import React, { FC, ReactNode } from 'react';
+import { screen, render } from '@testing-library/react';
+
+import DeepFormat from '../src/util/DeepFormat';
+import HandleOverloads from '../src/util/HandleOverloads';
+import { Overload, RenderAll } from '../src/interfaces/Overload';
+import { Button, IButton } from '../src/components/Button/Button';
+
+/**
+ * Interface for test overload component
+ */
+interface ITestOverload extends Overload<IButton> {
+    parentProps: { test: string };
+}
+
+/**
+ * Test Overload
+ *
+ * @return test overload component
+ */
+const TestOverload: FC<ITestOverload> = ({ parentProps: { test }, children, ...props }) => {
+    return <button {...props}>{test}</button>;
+};
+
+/**
+ * Interface for test component
+ */
+interface ITestComponent {
+    test: string;
+    children: ReactNode;
+}
+
+/**
+ * Test component
+ *
+ * @return test component
+ */
+export const TestComponent: FC<ITestComponent> = ({ children, test }) => {
+    /**
+     * Function that simulates standard renderAll function
+     *
+     * @return formatted children
+     */
+    const renderAll: RenderAll = () => {
+        // define all necessary params
+        const parentProps = { test };
+        const componentMap = { Button: TestOverload };
+
+        // get deep format
+        const deepFormat = new DeepFormat(children, componentMap, parentProps);
+
+        // return formatted children
+        return deepFormat.getAll();
+    };
+
+    return <div>{renderAll()}</div>;
+};
+
+interface IWrappedTarget {
+    children: ReactNode;
+}
+
+/**
+ * Wraps the target component
+ *
+ * @return wrapped target to be replaced
+ */
+export const WrappedTarget: FC<IWrappedTarget> = ({ children, ...props }) => {
+    return (
+        <HandleOverloads props={props}>
+            <div>
+                {children}
+                <Button>Something else</Button>
+            </div>
+        </HandleOverloads>
+    );
+};
+
+describe('DeepFormat', () => {
+    it('should render all non-apollo children normally', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <div>Hello</div>
+                <button>World</button>
+                <span>
+                    <span>This is amazing</span>
+                </span>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.getByText('Hello')).toBeInTheDocument();
+        expect(screen.getByText('World')).toBeInTheDocument();
+        expect(screen.getByText('This is amazing')).toBeInTheDocument();
+    });
+
+    it('should replace apollo components without impacting adjacent children', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <Button>Hello</Button>
+                <button>World</button>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.getByText('World')).toBeInTheDocument();
+        expect(screen.getByText('test')).toBeInTheDocument();
+        expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+    });
+
+    it('should replace apollo components that are deeply nested', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <div>
+                    <div>
+                        <div>
+                            <Button>Hello</Button>
+                        </div>
+                    </div>
+                </div>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.getByText('test')).toBeInTheDocument();
+        expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+    });
+
+    it('should replace apollo components that are deeply nested and have adjacent children', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <div>
+                    <div>
+                        <div>
+                            <Button>Hello</Button>
+                            <div>World</div>
+                        </div>
+                    </div>
+                </div>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.getByText('test')).toBeInTheDocument();
+        expect(screen.getByText('World')).toBeInTheDocument();
+        expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+    });
+
+    it('should replace children with different depths without impacting adjacents', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <Button>Button 1</Button>
+                <div>
+                    <div>Hello</div>
+                    <Button>Button 2</Button>
+                    <div>
+                        <div>World</div>
+                        <Button>Button 3</Button>
+                    </div>
+                </div>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.queryAllByText('test')).toHaveLength(3);
+        expect(screen.getByText('World')).toBeInTheDocument();
+        expect(screen.queryByText('Hello')).toBeInTheDocument();
+    });
+
+    it('should replace children that are wrapped by another component', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <WrappedTarget apollo-overloads={{ Button }}>
+                    <p>This is pretty cool</p>
+                </WrappedTarget>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.queryAllByText('test')).toHaveLength(1);
+        expect(screen.getByText('This is pretty cool')).toBeInTheDocument();
+    });
+
+    it('should replace all children indescriminately', () => {
+        // given
+        render(
+            <TestComponent test="test">
+                <WrappedTarget apollo-overloads={{ Button }}>
+                    <p>This is pretty cool</p>
+                </WrappedTarget>
+                <Button>This is cool</Button>
+            </TestComponent>
+        );
+
+        // when then
+        expect(screen.queryAllByText('test')).toHaveLength(2);
+        expect(screen.getByText('This is pretty cool')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# Introducing `DeepFormat`
Fixes MIL-1828, MIL-1833

## Purpose
The great thing about Apollo is the seamless integrations and quick processing that we do behind the scenes to remove boilerplate and extra work for users. This works because of our `FormatChildren` algorithm that looks at the top level nodes of the DOM and replaces the Apollo equivalents with an Overloaded version that has features specific to a distinct context. 

The only issue with this approach was that any child nested in other non-Apollo components or even wrapped by a user defined component would not be able to get these features, this was noted in QS and Aurora. Meaning, if we had this:

```typescript
function SpecialTextInput() {
  return <TextInput />
}

function LoginForm() {
  return (
    <Form>
      <TextInput /> //<- this would have live validation
      <div>
        <div>
          <div>
            <TextInput /> //<- this one wouldn't because it's too deeply nested
          </div>
        </div>
      </div>
      <SpecialTextInput /> //<- this wouldn't because it's wrapped by non-apollo 
    </Form>
  )
}
```

Which was an issue that ended **inconveniencing** devleopment. So we had to come up with a solution.

## Summary of Changes

The above problem was solved with our `DeepFormat` algorithm. `DeepFormat` will now look into all valid children in the DOM tree and overload Apollo components regardless of depth. Additionally, for components that were abstracted into user-made components, we introduced the `HandleOverloads` wrapper, which will perpetuate `DeepFormat` even in components that aren't immediately available to the DOM due to React hydration.

So now with a little bit of tweaking, the Form showed above can look like this:

```typescript
function SpecialTextInput(props) {
  return (
    <OverloadWrapper props={props}> <- wrapper with special abilities
      <TextInput />
    </OverloadWrapper>
  )
}

function LoginForm() {
  return (
    <Form>
      <TextInput /> //<- this would have live validation
      <div>
        <div>
          <div>
            <TextInput /> //<- this one as well
          </div>
        </div>
      </div>
      <SpecialTextInput apollo-overrides={{ TextInput }} /> //<- this one too
    </Form>
  )
}
```

> **Note:** The Apollo `Form` component still does not implement `DeepFormat`. That was not in scope for this commit.


### Changelog
- Features
	- created `DeepFormat.tsx` which handles overlading heavily nested Apollo components, and user-abstracted components that render Apollo components
	- created `HandleOverloads` wrapper that assists in overloading user-abstracted Apollo components
- Tests
	- created a test-suite that tests the use of `DeepFormat` and `HandleOverloads`
- Housecleaning
  - removed unnecessary prop destructuring in `Button`

#### Image Title 1 (if applicable)
<image>

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.