### PR TITLE
Add orb to Circle CI that automatically deploys to NPM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
     node: circleci/node@4.7
+    npm-publisher: uraway/npm-publisher@0.2.0
 
 workflows:
     Test-Lint-Build-All-Versions:
@@ -28,3 +29,11 @@ workflows:
                           version: ['16.10', '14.17', '12.22']
                   pkg-manager: yarn
                   yarn-run: build
+    Publish:
+        jobs:
+            - npm-publisher/publish-from-package-version:
+                push-git-tag: true 
+                filters: 
+                    branches:
+                        only:
+                            - main


### PR DESCRIPTION
# Add orb to Circle CI that automatically deploys to NPM

- Fixes MIL-1886 (if applicable, internal G2X use only)

## Purpose
Our current development environment for Apollo lacks automatic deployment to NPM, so we should add it such that every-time an update is pushed to main, we can automatically update the Apollo API.

## Summary of Changes
Add an orb to CirceCI that will handle automatic deployment to NPM

### Changelog
- Features
	- edited circleci config to deploy to npm when main is updated
	
# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.