### PR TITLE
feature: added value to calendar

### DIFF
--- a/src/components/Calendar/Calendar.css
+++ b/src/components/Calendar/Calendar.css
@@ -31,7 +31,7 @@
 }
 
 .apollodate.not-current {
-    color: #88949D;
+    color: #6c757c;
 }
 
 .apollodate.active {
@@ -50,4 +50,8 @@
     background: #C1C7CB;
     width: 100%;
     margin-bottom: 15px;
+}
+
+.apollo[data-apollo="Icon"].apollodate-controls {
+    color: #6c757c
 }

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -24,6 +24,11 @@ export interface ICalendar extends Apollo<'Calendar'> {
      * with a dot signfiying importance.
      */
     marks?: Array<string>;
+    /**
+     * Date tuple that will override the current value. This should be a tuple of dates where
+     * the first date is the start date and the second date is the end date.
+     */
+    value?: [string] | [string, string];
     /** Determines what date the calendar starts on, by default it's the current date */
     startDate?: string;
     /**
@@ -50,6 +55,7 @@ export const Calendar: FC<ICalendar> = ({
     type = 'single',
     startDate,
     dateRange,
+    value,
     marks,
     theme = 'primary',
     onChange,
@@ -62,9 +68,11 @@ export const Calendar: FC<ICalendar> = ({
 
     // date range standardized to "YYYY/MM/DD-YYYY/MM/DD"
     if (dateRange) {
-        const start = getTimezoneDate(dateRange[0]).toLocaleDateString();
-        const end = getTimezoneDate(dateRange[1]).toLocaleDateString();
-        dateRange = [start, end];
+        const [start, end] = dateRange;
+        dateRange = [
+            getTimezoneDate(start).toLocaleDateString(),
+            getTimezoneDate(end).toLocaleDateString(),
+        ];
     }
 
     // marks standardized to set of "YYYY/MM/DD"
@@ -86,22 +94,25 @@ export const Calendar: FC<ICalendar> = ({
                 aria-label="calendar month controls"
             >
                 <Icon
+                    className="apollodate-controls"
+                    theme={theme}
                     aria-label="previous month"
                     onClick={() => setDate('prev')}
                     name="keyboard_arrow_left"
-                    color="#5D6871"
                 />
                 <Text tabIndex={0} style={{ outline: 'none' }}>
                     {date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
                 </Text>
                 <Icon
+                    className="apollodate-controls"
+                    theme={theme}
                     aria-label="next month"
                     onClick={() => setDate('next')}
                     name="keyboard_arrow_right"
-                    color="#5D6871"
                 />
             </Section>
             <CalendarGrid
+                value={value}
                 type={type}
                 id={id}
                 fontSize={fontSize}

--- a/src/components/Calendar/components/CalendarCell.tsx
+++ b/src/components/Calendar/components/CalendarCell.tsx
@@ -58,7 +58,7 @@ export const CalendarCell: FC<ICalendarCell> = ({
         const startDate = new Date(start).getTime();
         isValid = startDate <= currentDate;
 
-        if (end) {
+        if (end?.length && end !== 'Invalid Date') {
             const endDate = new Date(end).getTime();
             isValid = isValid && endDate >= currentDate;
         }

--- a/src/components/Calendar/components/CalendarGrid.tsx
+++ b/src/components/Calendar/components/CalendarGrid.tsx
@@ -17,6 +17,7 @@ interface ICalendarGrid {
     fontSize?: CSS.Property.FontSize;
     id: string;
     setDate: (date: string) => void;
+    value?: [string] | [string, string];
 }
 
 /**
@@ -33,11 +34,12 @@ export const CalendarGrid: FC<ICalendarGrid> = ({
     startDate = new Date().toLocaleDateString(),
     type,
     id,
+    value,
     setDate,
     onChange,
 }) => {
     // handles current calendar selection
-    const [selected, updateSelected] = useSelection(type, startDate);
+    const [selected, updateSelected] = useSelection(type, startDate, value);
     useOnChange(selected, onChange);
 
     // get current month
@@ -46,6 +48,7 @@ export const CalendarGrid: FC<ICalendarGrid> = ({
     return (
         <>
             <CalendarRange
+                id={id}
                 type={type}
                 selected={selected}
                 setDate={setDate}
@@ -98,13 +101,26 @@ export const CalendarGrid: FC<ICalendarGrid> = ({
  *
  * @param type type of selection
  * @param startDate currently selected dates
+ * @param value override of current value
  * @return hooks that handle selection
  */
 const useSelection = (
     type: string,
-    startDate: string
+    startDate: string,
+    value?: [string] | [string, string]
 ): [string[], (date: string | [string] | [string, string]) => void] => {
     const [selected, updateSelected] = useState([getTimezoneDate(startDate).toLocaleDateString()]);
+
+    useEffect(() => {
+        if (!value?.length) return;
+        if (value === selected) return;
+        if (type === 'single' && value.length > 1) return;
+        if (value.length > 2) return;
+
+        // format the current value
+        const formattedValue = value.map((date) => getTimezoneDate(date).toLocaleDateString());
+        updateSelected(formattedValue);
+    }, [value]);
 
     return [
         selected,

--- a/src/components/Calendar/components/CalendarRange.tsx
+++ b/src/components/Calendar/components/CalendarRange.tsx
@@ -11,6 +11,7 @@ interface ICalendar {
     updateSelected: (date: string | [string] | [string, string]) => void;
     /**  */
     setDate: (date: string) => void;
+    id: string;
 }
 
 /**
@@ -18,7 +19,7 @@ interface ICalendar {
  *
  * @return Calendar Range input
  */
-export const CalendarRange: FC<ICalendar> = ({ type, selected, updateSelected, setDate }) => {
+export const CalendarRange: FC<ICalendar> = ({ type, id, selected, updateSelected, setDate }) => {
     const [range, setRange] = useRangeInput(selected, updateSelected, setDate);
 
     return type === 'range' ? (
@@ -31,7 +32,7 @@ export const CalendarRange: FC<ICalendar> = ({ type, selected, updateSelected, s
             <TextInput
                 placeholder="mm/dd/yyyy"
                 style={{ width: 120 }}
-                name="start"
+                name={`${id}-start`}
                 label="Start Date"
                 onChange={(e) => setRange('start', e)}
                 value={range.start}
@@ -40,7 +41,7 @@ export const CalendarRange: FC<ICalendar> = ({ type, selected, updateSelected, s
             <div className="apollo-range-divider" />
             <TextInput
                 style={{ width: 120 }}
-                name="end"
+                name={`${id}-end`}
                 label="End Date"
                 placeholder="mm/dd/yyyy"
                 onChange={(e) => setRange('end', e)}

--- a/src/components/Form/components/CSForm.tsx
+++ b/src/components/Form/components/CSForm.tsx
@@ -96,14 +96,14 @@ const CSForm: FC<ICSForm> = ({
     ): void => {
         // check if there is an onSubmit function
         if (!method?.length && onSubmit) {
-            handleSubmit(onSubmit, onError)(event);
+            handleSubmit(onSubmit, onError as any)(event);
             return;
         }
 
         // don't submit form if there are errors
         if (Object.keys(errors).length) {
             event.preventDefault();
-            if (onError) onError(errors);
+            if (onError) onError(errors as any);
             return;
         }
 

--- a/test/Calendar.test.tsx
+++ b/test/Calendar.test.tsx
@@ -189,4 +189,68 @@ describe('Calendar', () => {
         // then
         expect(onChange).toHaveBeenCalledWith(['1/1/2021', '1/2/2021']);
     });
+
+    it('should override current default if there is a value present', () => {
+        // given
+        const onChange = jest.fn();
+        render(
+            <Calendar
+                id="testRange"
+                startDate="2021-01-01"
+                onChange={onChange}
+                type="range"
+                value={['2021-01-04', '2021-01-05']}
+            />
+        );
+        const start = screen.getByLabelText(/start date/i);
+        const end = screen.getByLabelText(/end date/i);
+
+        // whe then
+        expect(start).toHaveValue('1/4/2021');
+        expect(end).toHaveValue('1/5/2021');
+    });
+
+    it('should override value if user types in a date', async () => {
+        // given
+        const onChange = jest.fn();
+        render(
+            <Calendar
+                id="testRange"
+                startDate="2021-01-01"
+                onChange={onChange}
+                type="range"
+                value={['2021-01-04', '2021-01-05']}
+            />
+        );
+
+        // when
+        userEvent.clear(screen.getByLabelText(/start date/i));
+        await userEvent.type(screen.getByLabelText(/start date/i), '1202/2/1', { delay: 1 });
+        userEvent.clear(screen.getByLabelText(/end date/i));
+        await userEvent.type(screen.getByLabelText(/end date/i), '1202/3/1', { delay: 1 });
+
+        // then
+        expect(onChange).toHaveBeenCalledWith(['1/2/2021', '1/3/2021']);
+    });
+
+    it('should override value if user clicks on a date', async () => {
+        // given
+        const onChange = jest.fn();
+        render(
+            <Calendar
+                id="testRange"
+                startDate="2021-01-01"
+                onChange={onChange}
+                type="range"
+                value={['2021-01-04', '2021-01-05']}
+            />
+        );
+
+        // when
+        userEvent.click(screen.getByLabelText('Saturday, January 2'));
+        userEvent.click(screen.getByLabelText('Sunday, January 3'));
+
+        // then
+        expect(onChange).toHaveBeenCalledWith(['1/2/2021', '1/3/2021']);
+    });
 });


### PR DESCRIPTION
# Added value to Calendar

## Purpose
The purpose of this change is so that we can use form functionalities while also having external inputs control the values of the calendar making it more flexible to use.

## Summary of Changes
Added the ability to override the current value of the calendar through the `value` prop.

### Changelog
- Features
	- added `value` prop that can override whatever the current value in the calendar is
	- improved contrast for accessibility
	- added inherited theming to navigation buttons
- Tests
	- added tests to account for the new `value` behaviors
- Bugfixes (if applicable)
  - added support for a `startDate` only. In the `dateRange` prop.

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.